### PR TITLE
Fixed broken links to https://yld.io. Fixed broken yld.io logos.

### DIFF
--- a/archive.html
+++ b/archive.html
@@ -41,8 +41,8 @@
     </div>
     
     <div class="col-xs-12 col-md-4 col-lg-4 lnug-sidebar text-center">
-    <a href="https://yld.io" target="_blank" title="yld.io homepage proud sponsor of LNUG">
-      <img width="250" src="https://pbs.twimg.com/profile_images/460020880140021760/cJcgzrGo.png" alt="yld.io">
+    <a href="http://www.yld.io" target="_blank" title="yld.io homepage proud sponsor of LNUG">
+      <img width="250" src="https://pbs.twimg.com/profile_images/580703131136352256/F33CaDK0.png" alt="yld.io">
     </a>
     <a href="http://ly.st" target="_blank" title="yld.io homepage proud sponsor of LNUG">
       <img width="250" src="https://pbs.twimg.com/profile_images/499114585408827392/7ibmxtjr.png" alt="yld.io">

--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -72,8 +72,8 @@ LNUG is dedicated to providing a harassment-free meetup experience for everyone.
     </div>
     
     <div class="col-xs-12 col-md-4 col-lg-4 lnug-sidebar text-center">
-    <a href="https://yld.io" target="_blank" title="yld.io homepage proud sponsor of LNUG">
-      <img width="250" src="https://pbs.twimg.com/profile_images/460020880140021760/cJcgzrGo.png" alt="yld.io">
+    <a href="http://www.yld.io" target="_blank" title="yld.io homepage proud sponsor of LNUG">
+      <img width="250" src="https://pbs.twimg.com/profile_images/580703131136352256/F33CaDK0.png" alt="yld.io">
     </a>
     <a href="http://ly.st" target="_blank" title="yld.io homepage proud sponsor of LNUG">
       <img width="250" src="https://pbs.twimg.com/profile_images/499114585408827392/7ibmxtjr.png" alt="yld.io">

--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
     </div>
     
     <div class="col-xs-12 col-md-4 col-lg-4 lnug-sidebar text-center">
-    <a href="https://yld.io" target="_blank" title="yld.io homepage proud sponsor of LNUG">
+    <a href="http://www.yld.io" target="_blank" title="yld.io homepage proud sponsor of LNUG">
       <img width="250" src="https://pbs.twimg.com/profile_images/580703131136352256/F33CaDK0.png" alt="yld.io">
     </a>
     <a href="http://gocardless.com" target="_blank" title="goCardless">


### PR DESCRIPTION
I just noticed the links to yld.io were broken, so I fixed them. On pages other than home, the yld.io logo was using a broken image uri so I changed to match the homepage.
