### PR TITLE
manual changes to show the next event date and link to current tito page

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,13 +38,13 @@
               <div class="lnug-menu-text col-xs-12 col-lg-3"><a href="/">This month</a></div>
               <div class="lnug-menu-text col-xs-12 col-lg-3"><a href="/archive">Archive</a></div>
               <div class="lnug-menu-text col-xs-12 col-lg-3"><a href="https://gitter.im/lnug/discuss" target="_blank">Discuss</a></div>
-              <div class="lnug-menu-text col-xs-12 col-lg-3"><a id="lnug-tkt" href="https://ti.to/lnug/october-2015" target="_blank">Free Tickets</a></div>
+              <div class="lnug-menu-text col-xs-12 col-lg-3"><a id="lnug-tkt" href="https://ti.to/lnug/november-2015" target="_blank">Free Tickets</a></div>
             </div>
         </div>
       </div>
       <div class="lnug-nextevent">
         <div class="text-center">
-          <p>Next meetup: <span class="lnug-nextmeetup">October 28th 2015</span></p>
+          <p>Next meetup: <span class="lnug-nextmeetup">November 25th 2015</span></p>
         </div>
       </div>
     </div>
@@ -54,7 +54,7 @@
 
   <div class="row">
     <div class="row lnug-sectiondesc">
-       <div class="col-xs-12 col-md-8 text-center talk-label ">Talks</div>
+       <div class="col-xs-12 col-md-8 text-center talk-label ">October&apos;s Talks</div>
        <div class="col-xs-12 col-md-4 text-center sponsor-label hidden-xs hidden-sm">Sponsors</div>
     </div>
 


### PR DESCRIPTION
These minor changes update the auto-generated page to show the date of the next event, but without it being necessary for us to have all the details of the next talks ready now. It's intentional to change the auto-generated page itself, so that the change from Talks to October's talks is removed when the automatic process is run.

The changes mean that now anyone interested in lnug can see there is another event scheduled and, from last month's talks, get a feel for what we offer. The link to ti.to is for the upcoming event.

I've confirmed that the changes do not affect the automated process. If you check the automated process, be aware that due to the current state of the talks issues it needs a bit of manual assistance, but that's not due to these changes.
