### PR TITLE
set talk order

### DIFF
--- a/lib/speaker-selectors.js
+++ b/lib/speaker-selectors.js
@@ -15,7 +15,12 @@ function speakerSelectors (speaker) {
     }
   }
 }
+var sortByTitle = function(a, b) {
+  if(a.title < b.title) return -1;
+  if(a.title > b.title) return 1;
+  return 0;
+}
 
 module.exports = function (callback) {
-  return thisMonth.map(speakerSelectors)
+  return thisMonth.sort(sortByTitle).map(speakerSelectors)
 }


### PR DESCRIPTION
to fix the ordering of the talks on the website (they need prefixing with a number)