### PR TITLE
Add more video links to archive, plus small fixes to speakers

### DIFF
--- a/client/service-worker.js
+++ b/client/service-worker.js
@@ -1,6 +1,6 @@
 'use strict'
 var serviceWorker = require('speclate-service-worker')
 var spec = require('../spec')
-var version = '1.10'
+var version = '1.11'
 
 serviceWorker(spec, version)

--- a/data/archive.json
+++ b/data/archive.json
@@ -21,81 +21,97 @@
     },
     {
         "date": "January 2017",
+        "playlist-url": "https://www.youtube.com/playlist?list=PLam_80-FY3vTFIdJyDA-EJCOEYCVGO85F",
         "speakers": [
             {
                 "name": "Andy Trevorah",
                 "url": "https://github.com/trevorah",
-                "title": " Native app tips to save your sanity"
+                "title": "Native app tips to save your sanity",
+                "video": "https://youtu.be/UpELu7rfRVk?list=PLam_80-FY3vTFIdJyDA-EJCOEYCVGO85F"
             },
             {
                 "name": "Clement Hannicq",
                 "url": "https://github.com/clementhannicq",
-                "title": "GraphQL: an API convention that you will actually follow"
+                "title": "GraphQL: an API convention that you will actually follow",
+                "video": "https://youtu.be/Bv89egC_v6A?list=PLam_80-FY3vTFIdJyDA-EJCOEYCVGO85F"
             },
             {
                 "name": "Clarkie",
                 "url": "https://github.com/clarkie",
-                "title": "A year with AWS"
+                "title": "A year with AWS",
+                "video": "https://youtu.be/4yxHjeWvnR4?list=PLam_80-FY3vTFIdJyDA-EJCOEYCVGO85F"
             }
         ]
     },
     {
         "date": "November 2016",
+        "playlist-url": "https://www.youtube.com/playlist?list=PLam_80-FY3vRiyq1PZW3iaT114EKdEIRL",
         "speakers": [
+            {
+                "name": "Andreas Møller",
+                "url": "https://github.com/cullophid",
+                "title": "Keep calm and curry on",
+                "video": "https://youtu.be/4SGqCiU1_9E?list=PLam_80-FY3vRiyq1PZW3iaT114EKdEIRL"
+            },
             {
                 "name": "Stefano Vozza",
                 "url": "https://github.com/svozza",
-                "title": "2. Null Can&#39;t Hurt You Anymore"
+                "title": "Null Can&#39;t Hurt You Anymore",
+                "video": "https://youtu.be/-FV3ia_SyxA?list=PLam_80-FY3vRiyq1PZW3iaT114EKdEIRL"
             },
             {
                 "name": "James Chow (dsc)",
                 "url": "https://github.com/jc888",
-                "title": "3. Readable Microservices, with functional programming."
-            },
-            {
-                "name": "Andreas Møller",
-                "url": "https://github.com/cullophid",
-                "title": "1. Keep calm and curry on"
+                "title": "Readable Microservices, with functional programming.",
+                "video": "https://youtu.be/enXqi3jGHIs?list=PLam_80-FY3vRiyq1PZW3iaT114EKdEIRL"
             }
         ]
     },
     {
         "date": "October 2016",
+        "playlist-url": "https://www.youtube.com/playlist?list=PLam_80-FY3vRuXxmiB74vjZzWZRAUPowu",
         "speakers": [
             {
                 "name": "Booker ⚡",
                 "url": "https://github.com/bookercodes",
-                "title": "Write More Resilient JavaScript with Flow"
+                "title": "Write More Resilient JavaScript with Flow",
+                "video": "https://youtu.be/RTtujG65DiE?list=PLam_80-FY3vRuXxmiB74vjZzWZRAUPowu"
             },
             {
                 "name": "lazlojuly",
                 "url": "https://github.com/lazlojuly",
-                "title": "How to build a RESTful API"
+                "title": "How to build a RESTful API",
+                "video": "https://youtu.be/2SPBrczIzr0?list=PLam_80-FY3vRuXxmiB74vjZzWZRAUPowu"
             },
             {
                 "name": "Mike MacCana",
                 "url": "https://github.com/mikemaccana",
-                "title": "Quick wins with node and Google AMP"
+                "title": "Quick wins with node and Google AMP",
+                "video": "https://youtu.be/0sVjKPTvOMA?list=PLam_80-FY3vRuXxmiB74vjZzWZRAUPowu"
             }
         ]
     },
     {
         "date": "September 2016",
+        "playlist-url": "https://www.youtube.com/playlist?list=PLam_80-FY3vQm4oeCUsqhgIjcs3TojrbE",
         "speakers": [
             {
                 "name": "Fox Reymann",
                 "url": "https://github.com/foxreymann",
-                "title": "Ace JavaScript Interviews: Scoping and Hoisting"
+                "title": "Ace JavaScript Interviews: Scoping and Hoisting",
+                "video": "https://youtu.be/hr61xyYSP6k?list=PLam_80-FY3vQm4oeCUsqhgIjcs3TojrbE"
             },
             {
                 "name": "Loïc Faugeron",
                 "url": "https://github.com/gnugat",
-                "title": "Event Driven Architecture"
+                "title": "Event Driven Architecture",
+                "video": "https://youtu.be/BwqouUxn-bg?list=PLam_80-FY3vQm4oeCUsqhgIjcs3TojrbE"
             },
             {
                 "name": "Tanzim",
                 "url": "https://github.com/tanzim",
-                "title": "I&#39;ve got swagger. Have you?"
+                "title": "I&#39;ve got swagger. Have you?",
+                "video": "https://youtu.be/Dlo3e-0wB1E?list=PLam_80-FY3vQm4oeCUsqhgIjcs3TojrbE"
             }
         ]
     },
@@ -203,19 +219,22 @@
         "date": "March 2016",
         "speakers": [
             {
-                "name": "Peter Elger",
-                "url": "https://github.com/pelger",
-                "title": "Microservices development in node.js"
+                "name": "Simon Ordish",
+                "url": "https://github.com/ordishs",
+                "title": "Rethink DB and Node.js",
+                "video": "https://youtu.be/idOuNyE6cXY"
             },
             {
                 "name": "Mike Elsmore",
                 "url": "https://github.com/ukmadlz",
-                "title": "NoSQL is a lie"
+                "title": "NoSQL is a lie",
+                "video": "https://youtu.be/gECA-f78kWI"
             },
             {
                 "name": "Tanzim",
                 "url": "https://github.com/tanzim",
-                "title": "Computing at scale. Why you should already be using AWS Lambda"
+                "title": "Computing at scale. Why you should already be using AWS Lambda",
+                "video": "https://youtu.be/r4a7aIBNlg0"
             }
         ]
     },

--- a/docs/api/speclate/archive.json
+++ b/docs/api/speclate/archive.json
@@ -13,19 +13,19 @@
                 },
                 {
                     ".date": "January 2017",
-                    ".speakers": "<li> Native app tips to save your sanity -  <a href=\"https://github.com/trevorah\">Andy Trevorah</a> </li> <li>GraphQL: an API convention that you will actually follow -  <a href=\"https://github.com/clementhannicq\">Clement Hannicq</a> </li> <li>A year with AWS -  <a href=\"https://github.com/clarkie\">Clarkie</a> </li>"
+                    ".speakers": "<li><a href=\"https://youtu.be/UpELu7rfRVk?list=PLam_80-FY3vTFIdJyDA-EJCOEYCVGO85F\" target = \"_blank\">Native app tips to save your sanity</a> - <a href=\"https://github.com/trevorah\">Andy Trevorah</a> </li> <li><a href=\"https://youtu.be/Bv89egC_v6A?list=PLam_80-FY3vTFIdJyDA-EJCOEYCVGO85F\" target = \"_blank\">GraphQL: an API convention that you will actually follow</a> - <a href=\"https://github.com/clementhannicq\">Clement Hannicq</a> </li> <li><a href=\"https://youtu.be/4yxHjeWvnR4?list=PLam_80-FY3vTFIdJyDA-EJCOEYCVGO85F\" target = \"_blank\">A year with AWS</a> - <a href=\"https://github.com/clarkie\">Clarkie</a> </li>"
                 },
                 {
                     ".date": "November 2016",
-                    ".speakers": "<li>2. Null Can&#39;t Hurt You Anymore -  <a href=\"https://github.com/svozza\">Stefano Vozza</a> </li> <li>3. Readable Microservices, with functional programming. -  <a href=\"https://github.com/jc888\">James Chow (dsc)</a> </li> <li>1. Keep calm and curry on -  <a href=\"https://github.com/cullophid\">Andreas M&Oslash;ller</a> </li>"
+                    ".speakers": "<li><a href=\"https://youtu.be/4SGqCiU1_9E?list=PLam_80-FY3vRiyq1PZW3iaT114EKdEIRL\" target = \"_blank\">Keep calm and curry on</a> - <a href=\"https://github.com/cullophid\">Andreas M&Oslash;ller</a> </li> <li><a href=\"https://youtu.be/-FV3ia_SyxA?list=PLam_80-FY3vRiyq1PZW3iaT114EKdEIRL\" target = \"_blank\">Null Can&#39;t Hurt You Anymore</a> - <a href=\"https://github.com/svozza\">Stefano Vozza</a> </li> <li><a href=\"https://youtu.be/enXqi3jGHIs?list=PLam_80-FY3vRiyq1PZW3iaT114EKdEIRL\" target = \"_blank\">Readable Microservices, with functional programming.</a> - <a href=\"https://github.com/jc888\">James Chow (dsc)</a> </li>"
                 },
                 {
                     ".date": "October 2016",
-                    ".speakers": "<li>Write More Resilient JavaScript with Flow -  <a href=\"https://github.com/bookercodes\">Booker &#9889;</a> </li> <li>How to build a RESTful API -  <a href=\"https://github.com/lazlojuly\">lazlojuly</a> </li> <li>Quick wins with node and Google AMP -  <a href=\"https://github.com/mikemaccana\">Mike MacCana</a> </li>"
+                    ".speakers": "<li><a href=\"https://youtu.be/RTtujG65DiE?list=PLam_80-FY3vRuXxmiB74vjZzWZRAUPowu\" target = \"_blank\">Write More Resilient JavaScript with Flow</a> - <a href=\"https://github.com/bookercodes\">Booker &#9889;</a> </li> <li><a href=\"https://youtu.be/2SPBrczIzr0?list=PLam_80-FY3vRuXxmiB74vjZzWZRAUPowu\" target = \"_blank\">How to build a RESTful API</a> - <a href=\"https://github.com/lazlojuly\">lazlojuly</a> </li> <li><a href=\"https://youtu.be/0sVjKPTvOMA?list=PLam_80-FY3vRuXxmiB74vjZzWZRAUPowu\" target = \"_blank\">Quick wins with node and Google AMP</a> - <a href=\"https://github.com/mikemaccana\">Mike MacCana</a> </li>"
                 },
                 {
                     ".date": "September 2016",
-                    ".speakers": "<li>Ace JavaScript Interviews: Scoping and Hoisting -  <a href=\"https://github.com/foxreymann\">Fox Reymann</a> </li> <li>Event Driven Architecture -  <a href=\"https://github.com/gnugat\">Lo&iuml;c Faugeron</a> </li> <li>I&#39;ve got swagger. Have you? -  <a href=\"https://github.com/tanzim\">Tanzim</a> </li>"
+                    ".speakers": "<li><a href=\"https://youtu.be/hr61xyYSP6k?list=PLam_80-FY3vQm4oeCUsqhgIjcs3TojrbE\" target = \"_blank\">Ace JavaScript Interviews: Scoping and Hoisting</a> - <a href=\"https://github.com/foxreymann\">Fox Reymann</a> </li> <li><a href=\"https://youtu.be/BwqouUxn-bg?list=PLam_80-FY3vQm4oeCUsqhgIjcs3TojrbE\" target = \"_blank\">Event Driven Architecture</a> - <a href=\"https://github.com/gnugat\">Lo&iuml;c Faugeron</a> </li> <li><a href=\"https://youtu.be/Dlo3e-0wB1E?list=PLam_80-FY3vQm4oeCUsqhgIjcs3TojrbE\" target = \"_blank\">I&#39;ve got swagger. Have you?</a> - <a href=\"https://github.com/tanzim\">Tanzim</a> </li>"
                 },
                 {
                     ".date": "August 2016",
@@ -49,7 +49,7 @@
                 },
                 {
                     ".date": "March 2016",
-                    ".speakers": "<li>Microservices development in node.js -  <a href=\"https://github.com/pelger\">Peter Elger</a> </li> <li>NoSQL is a lie -  <a href=\"https://github.com/ukmadlz\">Mike Elsmore</a> </li> <li>Computing at scale. Why you should already be using AWS Lambda -  <a href=\"https://github.com/tanzim\">Tanzim</a> </li>"
+                    ".speakers": "<li><a href=\"https://youtu.be/idOuNyE6cXY\" target = \"_blank\">Rethink DB and Node.js</a> - <a href=\"https://github.com/ordishs\">Simon Ordish</a> </li> <li><a href=\"https://youtu.be/gECA-f78kWI\" target = \"_blank\">NoSQL is a lie</a> - <a href=\"https://github.com/ukmadlz\">Mike Elsmore</a> </li> <li><a href=\"https://youtu.be/r4a7aIBNlg0\" target = \"_blank\">Computing at scale. Why you should already be using AWS Lambda</a> - <a href=\"https://github.com/tanzim\">Tanzim</a> </li>"
                 },
                 {
                     ".date": "February 2016",

--- a/docs/archive.html
+++ b/docs/archive.html
@@ -52,25 +52,25 @@
 </dd>
 <h2 class="date">January 2017</h2>
 <a class="lanyrd"></a>
-<ul class="speakers"><li> Native app tips to save your sanity -  <a href="https://github.com/trevorah">Andy Trevorah</a> </li> <li>GraphQL: an API convention that you will actually follow -  <a href="https://github.com/clementhannicq">Clement Hannicq</a> </li> <li>A year with AWS -  <a href="https://github.com/clarkie">Clarkie</a> </li></ul>
+<ul class="speakers"><li><a href="https://youtu.be/UpELu7rfRVk?list=PLam_80-FY3vTFIdJyDA-EJCOEYCVGO85F" target="_blank">Native app tips to save your sanity</a> - <a href="https://github.com/trevorah">Andy Trevorah</a> </li> <li><a href="https://youtu.be/Bv89egC_v6A?list=PLam_80-FY3vTFIdJyDA-EJCOEYCVGO85F" target="_blank">GraphQL: an API convention that you will actually follow</a> - <a href="https://github.com/clementhannicq">Clement Hannicq</a> </li> <li><a href="https://youtu.be/4yxHjeWvnR4?list=PLam_80-FY3vTFIdJyDA-EJCOEYCVGO85F" target="_blank">A year with AWS</a> - <a href="https://github.com/clarkie">Clarkie</a> </li></ul>
 <dd>
   <span></span>
 </dd>
 <h2 class="date">November 2016</h2>
 <a class="lanyrd"></a>
-<ul class="speakers"><li>2. Null Can&apos;t Hurt You Anymore -  <a href="https://github.com/svozza">Stefano Vozza</a> </li> <li>3. Readable Microservices, with functional programming. -  <a href="https://github.com/jc888">James Chow (dsc)</a> </li> <li>1. Keep calm and curry on -  <a href="https://github.com/cullophid">Andreas M&#xD8;ller</a> </li></ul>
+<ul class="speakers"><li><a href="https://youtu.be/4SGqCiU1_9E?list=PLam_80-FY3vRiyq1PZW3iaT114EKdEIRL" target="_blank">Keep calm and curry on</a> - <a href="https://github.com/cullophid">Andreas M&#xD8;ller</a> </li> <li><a href="https://youtu.be/-FV3ia_SyxA?list=PLam_80-FY3vRiyq1PZW3iaT114EKdEIRL" target="_blank">Null Can&apos;t Hurt You Anymore</a> - <a href="https://github.com/svozza">Stefano Vozza</a> </li> <li><a href="https://youtu.be/enXqi3jGHIs?list=PLam_80-FY3vRiyq1PZW3iaT114EKdEIRL" target="_blank">Readable Microservices, with functional programming.</a> - <a href="https://github.com/jc888">James Chow (dsc)</a> </li></ul>
 <dd>
   <span></span>
 </dd>
 <h2 class="date">October 2016</h2>
 <a class="lanyrd"></a>
-<ul class="speakers"><li>Write More Resilient JavaScript with Flow -  <a href="https://github.com/bookercodes">Booker &#x26A1;</a> </li> <li>How to build a RESTful API -  <a href="https://github.com/lazlojuly">lazlojuly</a> </li> <li>Quick wins with node and Google AMP -  <a href="https://github.com/mikemaccana">Mike MacCana</a> </li></ul>
+<ul class="speakers"><li><a href="https://youtu.be/RTtujG65DiE?list=PLam_80-FY3vRuXxmiB74vjZzWZRAUPowu" target="_blank">Write More Resilient JavaScript with Flow</a> - <a href="https://github.com/bookercodes">Booker &#x26A1;</a> </li> <li><a href="https://youtu.be/2SPBrczIzr0?list=PLam_80-FY3vRuXxmiB74vjZzWZRAUPowu" target="_blank">How to build a RESTful API</a> - <a href="https://github.com/lazlojuly">lazlojuly</a> </li> <li><a href="https://youtu.be/0sVjKPTvOMA?list=PLam_80-FY3vRuXxmiB74vjZzWZRAUPowu" target="_blank">Quick wins with node and Google AMP</a> - <a href="https://github.com/mikemaccana">Mike MacCana</a> </li></ul>
 <dd>
   <span></span>
 </dd>
 <h2 class="date">September 2016</h2>
 <a class="lanyrd"></a>
-<ul class="speakers"><li>Ace JavaScript Interviews: Scoping and Hoisting -  <a href="https://github.com/foxreymann">Fox Reymann</a> </li> <li>Event Driven Architecture -  <a href="https://github.com/gnugat">Lo&#xEF;c Faugeron</a> </li> <li>I&apos;ve got swagger. Have you? -  <a href="https://github.com/tanzim">Tanzim</a> </li></ul>
+<ul class="speakers"><li><a href="https://youtu.be/hr61xyYSP6k?list=PLam_80-FY3vQm4oeCUsqhgIjcs3TojrbE" target="_blank">Ace JavaScript Interviews: Scoping and Hoisting</a> - <a href="https://github.com/foxreymann">Fox Reymann</a> </li> <li><a href="https://youtu.be/BwqouUxn-bg?list=PLam_80-FY3vQm4oeCUsqhgIjcs3TojrbE" target="_blank">Event Driven Architecture</a> - <a href="https://github.com/gnugat">Lo&#xEF;c Faugeron</a> </li> <li><a href="https://youtu.be/Dlo3e-0wB1E?list=PLam_80-FY3vQm4oeCUsqhgIjcs3TojrbE" target="_blank">I&apos;ve got swagger. Have you?</a> - <a href="https://github.com/tanzim">Tanzim</a> </li></ul>
 <dd>
   <span></span>
 </dd>
@@ -106,7 +106,7 @@
 </dd>
 <h2 class="date">March 2016</h2>
 <a class="lanyrd"></a>
-<ul class="speakers"><li>Microservices development in node.js -  <a href="https://github.com/pelger">Peter Elger</a> </li> <li>NoSQL is a lie -  <a href="https://github.com/ukmadlz">Mike Elsmore</a> </li> <li>Computing at scale. Why you should already be using AWS Lambda -  <a href="https://github.com/tanzim">Tanzim</a> </li></ul>
+<ul class="speakers"><li><a href="https://youtu.be/idOuNyE6cXY" target="_blank">Rethink DB and Node.js</a> - <a href="https://github.com/ordishs">Simon Ordish</a> </li> <li><a href="https://youtu.be/gECA-f78kWI" target="_blank">NoSQL is a lie</a> - <a href="https://github.com/ukmadlz">Mike Elsmore</a> </li> <li><a href="https://youtu.be/r4a7aIBNlg0" target="_blank">Computing at scale. Why you should already be using AWS Lambda</a> - <a href="https://github.com/tanzim">Tanzim</a> </li></ul>
 <dd>
   <span></span>
 </dd>

--- a/docs/manifest.appcache
+++ b/docs/manifest.appcache
@@ -41,6 +41,6 @@ appcache-loader.html
 /related-meetups.html
 /pages/related-meetups/related-meetups.html
 /api/speclate/related-meetups.json
-# v-1486422579420
+# v-1487252085524
 NETWORK:
 *

--- a/docs/service-worker.js
+++ b/docs/service-worker.js
@@ -2,7 +2,7 @@
 'use strict'
 var serviceWorker = require('speclate-service-worker')
 var spec = require('../spec')
-var version = '1.10'
+var version = '1.11'
 
 serviceWorker(spec, version)
 
@@ -30,81 +30,97 @@ module.exports=[
     },
     {
         "date": "January 2017",
+        "playlist-url": "https://www.youtube.com/playlist?list=PLam_80-FY3vTFIdJyDA-EJCOEYCVGO85F",
         "speakers": [
             {
                 "name": "Andy Trevorah",
                 "url": "https://github.com/trevorah",
-                "title": " Native app tips to save your sanity"
+                "title": "Native app tips to save your sanity",
+                "video": "https://youtu.be/UpELu7rfRVk?list=PLam_80-FY3vTFIdJyDA-EJCOEYCVGO85F"
             },
             {
                 "name": "Clement Hannicq",
                 "url": "https://github.com/clementhannicq",
-                "title": "GraphQL: an API convention that you will actually follow"
+                "title": "GraphQL: an API convention that you will actually follow",
+                "video": "https://youtu.be/Bv89egC_v6A?list=PLam_80-FY3vTFIdJyDA-EJCOEYCVGO85F"
             },
             {
                 "name": "Clarkie",
                 "url": "https://github.com/clarkie",
-                "title": "A year with AWS"
+                "title": "A year with AWS",
+                "video": "https://youtu.be/4yxHjeWvnR4?list=PLam_80-FY3vTFIdJyDA-EJCOEYCVGO85F"
             }
         ]
     },
     {
         "date": "November 2016",
+        "playlist-url": "https://www.youtube.com/playlist?list=PLam_80-FY3vRiyq1PZW3iaT114EKdEIRL",
         "speakers": [
+            {
+                "name": "Andreas Møller",
+                "url": "https://github.com/cullophid",
+                "title": "Keep calm and curry on",
+                "video": "https://youtu.be/4SGqCiU1_9E?list=PLam_80-FY3vRiyq1PZW3iaT114EKdEIRL"
+            },
             {
                 "name": "Stefano Vozza",
                 "url": "https://github.com/svozza",
-                "title": "2. Null Can&#39;t Hurt You Anymore"
+                "title": "Null Can&#39;t Hurt You Anymore",
+                "video": "https://youtu.be/-FV3ia_SyxA?list=PLam_80-FY3vRiyq1PZW3iaT114EKdEIRL"
             },
             {
                 "name": "James Chow (dsc)",
                 "url": "https://github.com/jc888",
-                "title": "3. Readable Microservices, with functional programming."
-            },
-            {
-                "name": "Andreas Møller",
-                "url": "https://github.com/cullophid",
-                "title": "1. Keep calm and curry on"
+                "title": "Readable Microservices, with functional programming.",
+                "video": "https://youtu.be/enXqi3jGHIs?list=PLam_80-FY3vRiyq1PZW3iaT114EKdEIRL"
             }
         ]
     },
     {
         "date": "October 2016",
+        "playlist-url": "https://www.youtube.com/playlist?list=PLam_80-FY3vRuXxmiB74vjZzWZRAUPowu",
         "speakers": [
             {
                 "name": "Booker ⚡",
                 "url": "https://github.com/bookercodes",
-                "title": "Write More Resilient JavaScript with Flow"
+                "title": "Write More Resilient JavaScript with Flow",
+                "video": "https://youtu.be/RTtujG65DiE?list=PLam_80-FY3vRuXxmiB74vjZzWZRAUPowu"
             },
             {
                 "name": "lazlojuly",
                 "url": "https://github.com/lazlojuly",
-                "title": "How to build a RESTful API"
+                "title": "How to build a RESTful API",
+                "video": "https://youtu.be/2SPBrczIzr0?list=PLam_80-FY3vRuXxmiB74vjZzWZRAUPowu"
             },
             {
                 "name": "Mike MacCana",
                 "url": "https://github.com/mikemaccana",
-                "title": "Quick wins with node and Google AMP"
+                "title": "Quick wins with node and Google AMP",
+                "video": "https://youtu.be/0sVjKPTvOMA?list=PLam_80-FY3vRuXxmiB74vjZzWZRAUPowu"
             }
         ]
     },
     {
         "date": "September 2016",
+        "playlist-url": "https://www.youtube.com/playlist?list=PLam_80-FY3vQm4oeCUsqhgIjcs3TojrbE",
         "speakers": [
             {
                 "name": "Fox Reymann",
                 "url": "https://github.com/foxreymann",
-                "title": "Ace JavaScript Interviews: Scoping and Hoisting"
+                "title": "Ace JavaScript Interviews: Scoping and Hoisting",
+                "video": "https://youtu.be/hr61xyYSP6k?list=PLam_80-FY3vQm4oeCUsqhgIjcs3TojrbE"
             },
             {
                 "name": "Loïc Faugeron",
                 "url": "https://github.com/gnugat",
-                "title": "Event Driven Architecture"
+                "title": "Event Driven Architecture",
+                "video": "https://youtu.be/BwqouUxn-bg?list=PLam_80-FY3vQm4oeCUsqhgIjcs3TojrbE"
             },
             {
                 "name": "Tanzim",
                 "url": "https://github.com/tanzim",
-                "title": "I&#39;ve got swagger. Have you?"
+                "title": "I&#39;ve got swagger. Have you?",
+                "video": "https://youtu.be/Dlo3e-0wB1E?list=PLam_80-FY3vQm4oeCUsqhgIjcs3TojrbE"
             }
         ]
     },
@@ -212,19 +228,22 @@ module.exports=[
         "date": "March 2016",
         "speakers": [
             {
-                "name": "Peter Elger",
-                "url": "https://github.com/pelger",
-                "title": "Microservices development in node.js"
+                "name": "Simon Ordish",
+                "url": "https://github.com/ordishs",
+                "title": "Rethink DB and Node.js",
+                "video": "https://youtu.be/idOuNyE6cXY"
             },
             {
                 "name": "Mike Elsmore",
                 "url": "https://github.com/ukmadlz",
-                "title": "NoSQL is a lie"
+                "title": "NoSQL is a lie",
+                "video": "https://youtu.be/gECA-f78kWI"
             },
             {
                 "name": "Tanzim",
                 "url": "https://github.com/tanzim",
-                "title": "Computing at scale. Why you should already be using AWS Lambda"
+                "title": "Computing at scale. Why you should already be using AWS Lambda",
+                "video": "https://youtu.be/r4a7aIBNlg0"
             }
         ]
     },


### PR DESCRIPTION
Affects: http://localhost:3000/archive.html

Adding more youtube links for #96 🙌 😄 

### Additional changes:

- IIRC, Peter Elger had to drop out in March 2016 and Simon Ordish stepped in? This changes the speaker list for that month accordingly, and added the link to the video of Simon's talk.

- Removes a space before one of the talk titles

- Commit the generated files

- bump the service worker version number

- Remove numbering from talk titles of November 2016, and switch the order to match the youtube playlist

### Notes

- Is [`api/archive.json`](https://github.com/lnug/website/blob/master/api/archive.json) still in use anywhere? Can this file be deleted? I can't see any usages, and it appears to duplicate data in `data/archive.json`. Therefore I have not applied any changes to `api/archive.json`.

~~I have not committed any of the generated changes let me know if you would like them added~~
	client/service-worker.js
	docs/api/speclate/archive.json
	docs/archive.html
	docs/manifest.appcache
	docs/service-worker.js 

^^ UPDATE: have now committed the generated changes and the SW bump