### PR TITLE
apply html encoding in talk descriptions 

### DIFF
--- a/lib/model-talk.js
+++ b/lib/model-talk.js
@@ -3,6 +3,16 @@ var encoder = new Encoder('entity')
 var marked = require('marked')
 
 module.exports = function (talk) {
+  var tokens = marked.lexer(talk.body);
+  var htmlEncodedTokens = tokens.map(function(t){
+      t.text = encoder.htmlEncode(t.text);
+      return t;
+    });
+  htmlEncodedTokens.links = tokens.links;
+
+  
+  var talkDescription = marked.parser(htmlEncodedTokens);
+
   if (!talk.milestone) {
     throw new Error('No milestone for talk:' + talk.title)
   }
@@ -12,7 +22,7 @@ module.exports = function (talk) {
     apiSpeakerUrl: (talk.assignee) ? talk.assignee.url : talk.user.url,
     speakerUrl: (talk.assignee) ? talk.assignee.html_url : talk.user.html_url,
     title: encoder.htmlEncode(talk.title),
-    description: marked(encoder.htmlEncode(talk.body)),
+    description: talkDescription,
     milestone: talk.milestone.title
   }
 }


### PR DESCRIPTION
This has been bugging me for a while... talk descriptions and bios were coming out as a single long paragraph.

I found that the htmlencoder was removing line breaks before the marked parser could apply paragraphs - which made the talk descriptions appear on the site as a single long paragraph. 

The solution was to apply the htmlencoding to the marked tokens returned from the `marked.lexer` method - and this preserves the  paragraphs. 