### PR TITLE
use login (handle) if name is unavailable.

### DIFF
--- a/lib/get-speaker-detail.js
+++ b/lib/get-speaker-detail.js
@@ -13,7 +13,7 @@ module.exports = function (talk, callback) {
       }
       talk.img = data.body.avatar_url
       talk.handle = data.body.login
-      talk.name = data.body.name
+      talk.name = data.body.name || data.body.login
       callback(null, talk)
     })
 }


### PR DESCRIPTION
fix for #137.

It looks like the user who submitted the talk for next month does not have a name set against their github profile. 

It now defaults to their login handle when the name field is not available.

I will PR sizlate separately to ensure it does not crash in such situations. 

