### PR TITLE
adjusted language and layout around invitation to talk...

### DIFF
--- a/bin/update-json.js
+++ b/bin/update-json.js
@@ -38,16 +38,15 @@ superagent
         throw err
       }
 
-      while (completeAcceptedTalks.length < 3) {
         completeAcceptedTalks.push({
-          title: 'Slot available',
-          name: 'Submit your talk!',
-          description: 'This slot is still available, help us out: <a href="/speak.html">Submit a talk proposal</a>.',
+          title: 'Talk at LNUG',
+          name: 'Future speakers',
+          description: '<h3>We are a friendly crowd and would love to hear you talk.</h3> You may never have spoken at a meetup before, or you may be a seasoned conference speaker... either way, you probably have a node.js story to tell.  <a href="/speak.html">Submit a talk proposal</a> and we can help you prepare.',
           img: '/images/favicon/favicon-128.png',
           speakerUrl: 'https://lnug.org/speak.html',
           milestone: completeAcceptedTalks[0].milestone
         })
-      }
+
       fs.writeFile('./data/this-month.json', JSON.stringify(completeAcceptedTalks, null, 4), function () {
         console.log('Data file has been updated')
       })

--- a/css.css
+++ b/css.css
@@ -544,15 +544,15 @@ footer {
 @media (min-width: 1200px) {
     /* Talks ******************************************/
     .lnug-content {
-        display: flex;
         justify-content: space-between;
-        align-items: flex-start;
     }
     .lnug-talk {
         width: auto;
         display: inline-block;
         vertical-align: top;
-        max-width: 31%;
+        max-width: 29%;
+        min-width: 20%;
+        margin: 0 2%
     }
     .lnug-talk .title {
         min-height: 3em;

--- a/data/archive.json
+++ b/data/archive.json
@@ -13,9 +13,9 @@
                 "title": "Hapi + Nes + MiniMongo for gloryful reactive apps"
             },
             {
-                "name": "Submit your talk!",
+                "name": "Future speakers",
                 "url": "https://lnug.org/speak.html",
-                "title": "Slot available"
+                "title": "Talk at LNUG"
             }
         ]
     },

--- a/data/this-month.json
+++ b/data/this-month.json
@@ -20,9 +20,9 @@
         "name": "Alan Shaw"
     },
     {
-        "title": "Slot available",
-        "name": "Submit your talk!",
-        "description": "This slot is still available, help us out: <a href=\"/speak.html\">Submit a talk proposal</a>.",
+        "title": "Talk at LNUG",
+        "name": "Future speakers",
+        "description": "<h3>We are a friendly crowd and would love to hear you talk.</h3> You may never have spoken at a meetup before, or you may be a seasoned conference speaker... either way, you probably have a node.js story to tell.  <a href=\"/speak.html\">Submit a talk proposal</a> and we can help you prepare.",
         "img": "/images/favicon/favicon-128.png",
         "speakerUrl": "https://lnug.org/speak.html",
         "milestone": "September 27th 2017"

--- a/docs/api/speclate/archive.json
+++ b/docs/api/speclate/archive.json
@@ -7,7 +7,7 @@
             "data": [
                 {
                     ".date": "September 2017",
-                    ".speakers": "<li>Having your Node.js Cake and Eating It Too -  <a href=\"https://github.com/robtweed\">null</a> </li> <li>Hapi + Nes + MiniMongo for gloryful reactive apps -  <a href=\"https://github.com/alanshaw\">Alan Shaw</a> </li> <li>Slot available -  <a href=\"https://lnug.org/speak.html\">Submit your talk!</a> </li>"
+                    ".speakers": "<li>Having your Node.js Cake and Eating It Too -  <a href=\"https://github.com/robtweed\">null</a> </li> <li>Hapi + Nes + MiniMongo for gloryful reactive apps -  <a href=\"https://github.com/alanshaw\">Alan Shaw</a> </li> <li>Talk at LNUG -  <a href=\"https://lnug.org/speak.html\">Future speakers</a> </li>"
                 },
                 {
                     ".date": "August 2017",

--- a/docs/api/speclate/index.json
+++ b/docs/api/speclate/index.json
@@ -45,9 +45,9 @@
                     }
                 },
                 {
-                    ".name": "Submit your talk!",
-                    ".title": "Slot available",
-                    ".desc": "This slot is still available, help us out: <a href=\"/speak.html\">Submit a talk proposal</a>.",
+                    ".name": "Future speakers",
+                    ".title": "Talk at LNUG",
+                    ".desc": "<h3>We are a friendly crowd and would love to hear you talk.</h3> You may never have spoken at a meetup before, or you may be a seasoned conference speaker... either way, you probably have a node.js story to tell.  <a href=\"/speak.html\">Submit a talk proposal</a> and we can help you prepare.",
                     "img": {
                         "src": "/images/favicon/favicon-128.png"
                     },

--- a/docs/archive.html
+++ b/docs/archive.html
@@ -47,7 +47,7 @@
   <p>A archive of the past London Node User group meetups.</p>
   <ul class="archive"><h2 class="date">September 2017</h2>
 <a class="lanyrd"></a>
-<ul class="speakers"><li>Having your Node.js Cake and Eating It Too -  <a href="https://github.com/robtweed">null</a> </li> <li>Hapi + Nes + MiniMongo for gloryful reactive apps -  <a href="https://github.com/alanshaw">Alan Shaw</a> </li> <li>Slot available -  <a href="https://lnug.org/speak.html">Submit your talk!</a> </li></ul>
+<ul class="speakers"><li>Having your Node.js Cake and Eating It Too -  <a href="https://github.com/robtweed">null</a> </li> <li>Hapi + Nes + MiniMongo for gloryful reactive apps -  <a href="https://github.com/alanshaw">Alan Shaw</a> </li> <li>Talk at LNUG -  <a href="https://lnug.org/speak.html">Future speakers</a> </li></ul>
 <dd>
   <span></span>
 </dd>

--- a/docs/css.css
+++ b/docs/css.css
@@ -544,7 +544,7 @@ footer {
 @media (min-width: 1200px) {
     /* Talks ******************************************/
     .lnug-content {
-        display: flex;
+        /* display: flex; */
         justify-content: space-between;
         align-items: flex-start;
     }
@@ -552,7 +552,9 @@ footer {
         width: auto;
         display: inline-block;
         vertical-align: top;
-        max-width: 31%;
+        max-width: 29%;
+        min-width: 20%;
+        margin: 0 2%
     }
     .lnug-talk .title {
         min-height: 3em;

--- a/docs/index.html
+++ b/docs/index.html
@@ -95,12 +95,12 @@
 </div>
 </li>
 <li class="row lnug-talk">
-  <h2 class="title">Slot available</h2>
+  <h2 class="title">Talk at LNUG</h2>
   <div>
     <img class="img-circle avatar" alt="Speaker image" src="/images/favicon/favicon-128.png">
-    <span class="lnug-twitterhandle"><a href="https://lnug.org/speak.html"><span class="name">Submit your talk!</span></a></span>
+    <span class="lnug-twitterhandle"><a href="https://lnug.org/speak.html"><span class="name">Future speakers</span></a></span>
   </div>
-  <div class="desc">This slot is still available, help us out: <a href="/speak.html">Submit a talk proposal</a>.</div>
+  <div class="desc"><h3>We are a friendly crowd and would love to hear you talk.</h3> You may never have spoken at a meetup before, or you may be a seasoned conference speaker... either way, you probably have a node.js story to tell.  <a href="/speak.html">Submit a talk proposal</a> and we can help you prepare.</div>
 </li>
 </ul>
 

--- a/docs/manifest.appcache
+++ b/docs/manifest.appcache
@@ -42,6 +42,6 @@ appcache-loader.html
 /related-meetups.html
 /pages/related-meetups/related-meetups.html
 /api/speclate/related-meetups.json
-# v-1503567516421
+# v-1504212070753
 NETWORK:
 *

--- a/docs/service-worker.js
+++ b/docs/service-worker.js
@@ -22,9 +22,9 @@ module.exports=[
                 "title": "Hapi + Nes + MiniMongo for gloryful reactive apps"
             },
             {
-                "name": "Submit your talk!",
+                "name": "Future speakers",
                 "url": "https://lnug.org/speak.html",
-                "title": "Slot available"
+                "title": "Talk at LNUG"
             }
         ]
     },
@@ -1669,9 +1669,9 @@ module.exports=[
         "name": "Alan Shaw"
     },
     {
-        "title": "Slot available",
-        "name": "Submit your talk!",
-        "description": "This slot is still available, help us out: <a href=\"/speak.html\">Submit a talk proposal</a>.",
+        "title": "Talk at LNUG",
+        "name": "Future speakers",
+        "description": "<h3>We are a friendly crowd and would love to hear you talk.</h3> You may never have spoken at a meetup before, or you may be a seasoned conference speaker... either way, you probably have a node.js story to tell.  <a href=\"/speak.html\">Submit a talk proposal</a> and we can help you prepare.",
         "img": "/images/favicon/favicon-128.png",
         "speakerUrl": "https://lnug.org/speak.html",
         "milestone": "September 27th 2017"


### PR DESCRIPTION
quick answer to #140....

We have decided to have 2 speakers by default - but still allow for 3  or more

This PR changes accommodates only 2 speakers in layout and changes the language of the "Open slot" to make it more of a generic invitation to speak.  

The invitation to talk is now always present as the last slot in the list of speakers - and the layout now better accommodates 2, 3 or more speakers by wrapping to the next row if there are more than 3 items. 


