### PR TITLE
Issue #143 (Move google analytics code out of client.js) fix

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -1,13 +1,6 @@
 
-/* eslint-disable */
-
-// just a hack because the analytics stopped working, this should be moved back to a module.
-var analytics = function () {};
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','https://www.google-analytics.com/analytics.js','analytics');
-/* eslint-enable */
+var setupAnalytics = require('get-google-tracking-analytics')
+setupAnalytics()
 
 var router = require('speclate-router')
 var appCacheNanny = require('appcache-nanny')
@@ -19,7 +12,7 @@ router({
   },
   after: function () {
     $('html,body').scrollTop($('#container'))
-    analytics('send', 'pageview', {
+    ga('send', 'pageview', {
       page: window.location.pathname,
       title: document.title
     })
@@ -32,8 +25,8 @@ router({
   }
 })
 
-analytics('create', 'UA-2845245-14', 'auto')
-analytics('send', 'pageview')
+ga('create', 'UA-2845245-14', 'auto')
+ga('send', 'pageview')
 
 if ('serviceWorker' in navigator) {
   navigator.serviceWorker.register('/service-worker.js').then(function (registration) {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "async": "2.x.x",
     "browserify": "14.x.x",
     "chai": "4.x.x",
+    "get-google-tracking-analytics": "^1.0.2",
     "html-entities": "^1.1.3",
     "imagemagick-stream": "^4.0.1",
     "jquery": "3.x.x",
@@ -46,8 +47,7 @@
     "standard": "10.x.x",
     "superagent": "3.x.x"
   },
-  "dependencies": {
-  },
+  "dependencies": {},
   "standard": {
     "globals": [
       "$",


### PR DESCRIPTION
Hi,

I have created a NPM module, get-google-tracking-analytics, which provides the tracking analytics code.

```
module.exports = function () {
  window.GoogleAnalyticsObject = 'ga'
  window.ga = window.ga || function () {
    (window.ga.q = window.ga.q || []).push(arguments)
  }
  window.ga.l = 1 * new Date()
  var a = document.createElement('script')
  var m = document.getElementsByTagName('script')[0]
  a.async = 1
  a.src = 'https://www.google-analytics.com/analytics.js'
  m.parentNode.insertBefore(a, m)
}
```

I have updated client\index.js, removing the ugly tracking code and replacing it with:
```
var setupAnalytics = require('get-google-tracking-analytics')
setupAnalytics()
```

I have also replaced the method calls, analytics() is now ga().
```
ga('create', 'UA-2845245-14', 'auto')
ga('send', 'pageview')
```

Testing and verification completed:

I see 2 tracking events fired when first vising the site, one fired by the existing embedded JavaScript within the HTML and the 2nd from the client\index-compiled.js code.

I also see a page view tracking event fired each time I navigate to another page.

I believe this fulfils the requirements you specified. Please test yourself and let me know your thoughts.

Dom

 