### PR TITLE
fix footer links overlapping, add missing dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,5 +57,8 @@
       "app-cache-nanny.js",
       "client/index-compiled.js"
     ]
+  },
+  "devDependencies": {
+    "mocha": "^7.0.1"
   }
 }

--- a/pages/layout.html
+++ b/pages/layout.html
@@ -158,10 +158,15 @@
         list-style: none; 
  
     }
-
     .footer-links li {
-            margin:  1em 0;
+        margin: 0;
     }
+
+    .footer-links li a {
+        display: inline-block;
+        padding:  0.5em 0;
+    }
+
     nav a {       
         transition: color .6s;
     }
@@ -361,11 +366,11 @@ h1.talks {
     <div class="container">
       <object class="footer-logo" data="images/lnug-logo-monochrome.svg" type="image/svg+xml" >London Node User Group logo</object>
       <ul class="footer-links">
-        <li><a href="./related-meetups.html" title="related meetups">Related Meetups</a></li>
+        <li><a href="./related-meetups.html" title="Related Meetups">Related Meetups</a></li>
         <li><a href="./image-gallery.html" title="Gallery">Gallery</a></li>
-        <li><a href="./archive.html" title="archive">Archive</a></li>
-        <li><a href="./future.html" title="future">Future Events</a></li>
-        <li><a href="./code-of-conduct.html" title="Code of conduct">Code of Conduct</a></li>
+        <li><a href="./archive.html" title="Archive">Archive</a></li>
+        <li><a href="./future.html" title="Future">Future Events</a></li>
+        <li><a href="./code-of-conduct.html" title="Code of Conduct">Code of Conduct</a></li>
       </ul>
       <br />
       <small class="notice">


### PR DESCRIPTION
previously when hovering over the text for a footer link, the link below the one the cursor was over would be selected.

- rework styles such that hit areas do not overlap, and also make title attributes consistent with link text.
- add missing mocha dev dependency, such that unit tests can be run without installing mocha globally.

(for whatever reason I'm unable to attach screenshots, to reproduce hover over the links in the footer and observe the title popover)